### PR TITLE
Small fixups to Figure 11 reproduction

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,9 @@
 [submodule "portus"]
 	path = portus
 	url = https://github.com/ccp-project/portus
-[submodule "fct_scripts/empiricial-traffic-gen"]
-	path = fct_scripts/empiricial-traffic-gen
-	url = https://github.com/ccp-project/empiricial-traffic-gen
+[submodule "fct_scripts/empirical-traffic-gen"]
+	path = fct_scripts/empirical-traffic-gen
+	url = https://github.com/ccp-project/empirical-traffic-gen
 [submodule "generic-cong-avoid"]
 	path = generic-cong-avoid
 	url = https://github.com/ccp-project/generic-cong-avoid

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: ccp-kernel/ccp.ko mahimahi cubic reno bbr
+all: ccp-kernel/ccp.ko mahimahi empirical-traffic-gen cubic reno bbr
 
 ########################################
 # check that all the submodules are here
@@ -14,6 +14,7 @@ mahimahi/src/frontend/delayshell.cc ccp-kernel/libccp/ccp.h:
 clean:
 	$(MAKE) -C ccp-kernel clean
 	$(MAKE) -C mahimahi clean
+	$(MAKE) -C fct_scripts/empirical-traffic-gen clean
 
 ccp-kernel/ccp.ko: ccp-kernel/libccp/ccp.h
 	$(MAKE) -C ccp-kernel
@@ -31,6 +32,11 @@ mahimahi/src/frontend/mm-delay: mahimahi/src/frontend/delayshell.cc mahimahi/Mak
 
 mahimahi: mahimahi/src/frontend/mm-delay
 	sudo $(MAKE) -C mahimahi install
+
+# Empirical traffic gen
+
+empirical-traffic-gen:
+	$(MAKE) -C fct_scripts/empirical-traffic-gen
 
 # CCP algs
 

--- a/fct_scripts/client_script.sh
+++ b/fct_scripts/client_script.sh
@@ -2,6 +2,7 @@
 
 expConfig=$1
 logName=$2
+dir=$(dirname "$0")
 
 sleep 10
-/home/ubuntu/ccp-eval/fct_scripts/empirical-traffic-gen/bin/client -c $expConfig -l $logName -s 123
+$dir/empirical-traffic-gen/bin/client -c $expConfig -l $logName -s 123

--- a/fct_scripts/fct_exp.py
+++ b/fct_scripts/fct_exp.py
@@ -6,13 +6,13 @@ import subprocess as sh
 tcp_algs = ["ccp", "reno"]
 num_experiments = 1
 NUM_SERVERS = 50
-CAIDA_FILE =  "./empirical-traffic-gen/CAIDA_CDF"
+CAIDA_FILE =  "/ccp/fct_scripts/empirical-traffic-gen/CAIDA_CDF"
 client_config_params = {"load": "72Mbps", "fanout": "1 100", "num_reqs": "100000", "req_size_dist": CAIDA_FILE}
-server_binary = "./empirical-traffic-gen/bin/server"
-client_binary = "./empirical-traffic-gen/bin/client"
+server_binary = "/ccp/fct_scripts/empirical-traffic-gen/bin/server"
+client_binary = "/ccp/fct_scripts/empirical-traffic-gen/bin/client"
 tmp_file = "a.txt"
 NUM_EXPTS = 1
-PLOTTING_SCRIPT = "../plot/fct.r"
+PLOTTING_SCRIPT = "/ccp/plot/fct.r"
 
 
 # should be a multiple of 8
@@ -57,7 +57,7 @@ def spawn_servers(alg):
 
 def spawn_clients(mahimahi_file, exp_config, logname):
     # run mahimahi, set fq on the interface & run the client file
-    mahimahi_command = "mm-delay 25 mm-link {} {} --downlink-queue=droptail --downlink-queue-args=\'packets=800\' ./client_script.sh {} {}".format(mahimahi_file, mahimahi_file, exp_config, logname)
+    mahimahi_command = "mm-delay 25 mm-link {} {} --downlink-queue=droptail --downlink-queue-args=\'packets=800\' ./fct_scripts/client_script.sh {} {}".format(mahimahi_file, mahimahi_file, exp_config, logname)
     # command to set fq on the interface
     find_mahimahi = "sleep 1; x=$(ifconfig | grep delay | awk '{print $1}'| sed 's/://g') && sudo tc qdisc add dev $x root fq && echo $x"
     processes = []


### PR DESCRIPTION
This PR fixes some bugs I found when reproducing Figure 11 following the instructions in the README:

- `empiricial-traffic-gen` is renamed to `empirical-traffic-gen` inside fct_scripts.
- Added `empirical-traffic-gen` to Makefile.
- Fixed references inside `fct_exp.py` to be relative to root directory, not `fct_scripts`.
- client_script.sh path assumes it is running on a using ubuntu and a `ccp-eval`. I instead use a dynamic path to support both Vagrant and native users.

Tested works on a clean vagrant install.